### PR TITLE
Last update broke the serviceworker's show notification on change…

### DIFF
--- a/src/templates/layout.njk
+++ b/src/templates/layout.njk
@@ -8,5 +8,46 @@
         {% block content %} {% endblock %}
         {% include "./partials/_footer.njk" %}
         {% include "./partials/_scroll-to-top.njk" %}
+        <script>
+            // make the whole serviceworker process into a promise so later on we can
+            // listen to it and in case new content is available a toast will be shown
+            window.isUpdateAvailable = new Promise(function(resolve, reject) {
+                // lazy way of disabling service workers while developing
+                if ('serviceWorker' in navigator) {
+                    // register service worker file
+                    navigator.serviceWorker.register('/serviceworker.js')
+                        .then(reg => {
+                            reg.onupdatefound = () => {
+                                const installingWorker = reg.installing;
+                                installingWorker.onstatechange = () => {
+                                    switch (installingWorker.state) {
+                                        case 'installed':
+                                            if (navigator.serviceWorker.controller) {
+                                                // new update available
+                                                resolve(true);
+                                            } else {
+                                                // no update available
+                                                resolve(false);
+                                            }
+                                            break;
+                                    }
+                                };
+                            };
+                        })
+                        .catch(err => console.error('[SW ERROR]', err));
+                }
+            });
+
+            // listen to the service worker promise in index.html to see if there has been a new update.
+            // condition: the service-worker.js needs to have some kind of change - e.g. increment CACHE_VERSION.
+            window['isUpdateAvailable']
+                .then(isAvailable => {
+                    if (isAvailable) {
+                        // new update available
+                        let snackbar = document.getElementById('snackbar');
+                        snackbar.className = 'show';
+                    }
+                });
+        </script>
     </body>
 </html>

--- a/src/templates/macros/head.njk
+++ b/src/templates/macros/head.njk
@@ -57,45 +57,5 @@
                 });
             });
         } */
-
-        // make the whole serviceworker process into a promise so later on we can
-        // listen to it and in case new content is available a toast will be shown
-        window.isUpdateAvailable = new Promise(function(resolve, reject) {
-            // lazy way of disabling service workers while developing
-            if ('serviceWorker' in navigator) {
-                // register service worker file
-                navigator.serviceWorker.register('/serviceworker.js')
-                    .then(reg => {
-                        reg.onupdatefound = () => {
-                            const installingWorker = reg.installing;
-                            installingWorker.onstatechange = () => {
-                                switch (installingWorker.state) {
-                                    case 'installed':
-                                        if (navigator.serviceWorker.controller) {
-                                            // new update available
-                                            resolve(true);
-                                        } else {
-                                            // no update available
-                                            resolve(false);
-                                        }
-                                        break;
-                                }
-                            };
-                        };
-                    })
-                    .catch(err => console.error('[SW ERROR]', err));
-            }
-        });
-
-        // listen to the service worker promise in index.html to see if there has been a new update.
-        // condition: the service-worker.js needs to have some kind of change - e.g. increment CACHE_VERSION.
-        window['isUpdateAvailable']
-            .then(isAvailable => {
-                if (isAvailable) {
-                    // new update available
-                    let snackbar = document.getElementById('snackbar');
-                    snackbar.className = 'show';
-                }
-            });
     </script>
 {%- endmacro %}


### PR DESCRIPTION
Last update broke the serviceworker's show notification on change functionality because I moved the code in the head tag and may be it should stay in the end of body tag.